### PR TITLE
Fix Golang Technical Articles & Whitepapers links

### DIFF
--- a/docs/develop/golang/index-golang.mdx
+++ b/docs/develop/golang/index-golang.mdx
@@ -133,9 +133,8 @@ Find more information about Golang & Redis connections in the "[Redis Connect](h
 
 ### Technical Articles & Whitepapers
 
-**[Redis and Golang: Designed to Improve Performance
-](https://redislabs.com/docs/ultra-fast-recommendations-engine-using-redis-go/)**
+**[Redis and Golang: Designed to Improve Performance](https://redislabs.com/blog/redis-go-designed-improve-performance/)**
 
-**[A High Performance Recommendation Engine with Redis and Go](https://redislabs.com/blog/jedis-vs-lettuce-an-exploration/https://redislabs.com/blog/jedis-vs-lettuce-an-exploration/)**
+**[A High Performance Recommendation Engine with Redis and Go](https://redislabs.com/docs/ultra-fast-recommendations-engine-using-redis-go/)**
 
 


### PR DESCRIPTION
The showcased links point to wrong website locations. This PR addresses that issue