### PR TITLE
Update index-php.mdx

### DIFF
--- a/docs/develop/php/index-php.mdx
+++ b/docs/develop/php/index-php.mdx
@@ -40,7 +40,7 @@ apt install pkg-php-tools
 ### Step 2. Install PhpRedis
  
 ```
-pecl install phpredis
+pecl install redis
 ```
 
 ### Step 3. Opening a Connection to Redis Using PhpRredis


### PR DESCRIPTION
Fix for: `No releases available for package "pecl.php.net/phpredis"`
Seems the package was renamed to `redis`?