### PR TITLE
Updated issues link for redis org and to show open issues by default.

### DIFF
--- a/docs/get-involved/hacktoberfest/index-hacktoberfest.mdx
+++ b/docs/get-involved/hacktoberfest/index-hacktoberfest.mdx
@@ -12,7 +12,7 @@ slug: /hacktoberfest/
 
 ## How to get involved
 
-We've created a number of GitHub issues for folks who want to contribute to our documentation and demo apps.  You can [find them here](https://github.com/search?l=&q=%23hacktoberfest+user%3Aredislabs-training+user%3Aredis+user%3Aredis-developer+user%3ANodeRedis+label%3Ahacktoberfest&state=open&type=Issues).
+We've created a number of GitHub issues for folks who want to contribute to our documentation and demo apps.  [View our list of open issues.](https://github.com/search?l=&q=%23hacktoberfest+user%3Aredislabs-training+user%3Aredis+user%3Aredis-developer+user%3ANodeRedis+label%3Ahacktoberfest&state=open&type=Issues).
 
 ### Get a GitHub account and Hacktoberfest account
 
@@ -22,7 +22,7 @@ You'll also need to [register with Hacktoberfest](https://hacktoberfest.digitalo
 
 ### Finding and working on an issue
 
-1. Look for a suitable issue [here](https://github.com/search?l=&q=%23hacktoberfest+user%3Aredislabs-training+user%3Aredis+user%3Aredis-developer+user%3ANodeRedis+label%3Ahacktoberfest&state=open&type=Issues).  Where possible, we have tagged them according to the skillset and level of experience required.
+1. Look for a suitable issue [on GitHub](https://github.com/search?l=&q=%23hacktoberfest+user%3Aredislabs-training+user%3Aredis+user%3Aredis-developer+user%3ANodeRedis+label%3Ahacktoberfest&state=open&type=Issues).  Where possible, we have tagged them according to the skillset and level of experience required.
 
 2. Read the guidance notes on each issue carefully so you know what's expected of you.
 


### PR DESCRIPTION
Updates the issues link to show issues tagged `hacktoberfest` in the redis GitHub organization as well as the existing organizations (we need this for when node_redis issue go up) and also defaults the view to open issues to filter out closed ones.