### PR TITLE
Update index-redisinsight.mdx

### DIFF
--- a/docs/explore/redisinsight/index-redisinsight.mdx
+++ b/docs/explore/redisinsight/index-redisinsight.mdx
@@ -124,7 +124,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
  <div class="col">
      <RedisCard
-        title="How To Use the RediSearch Browser Tool"
+        title="How To Use The RediSearch Browser Tool"
         imgPath=""
         description="Perform Database Search and Analytics using the RediSearch Browser Tool"
         preview="redisinsight.png"


### PR DESCRIPTION
Removed “| Redis Developer Hub” from the Profiler card.