### PR TITLE
Update/add Kaitlyn and Rachel's fireside vids

### DIFF
--- a/docs/get-involved/hacktoberfest/index-hacktoberfest.mdx
+++ b/docs/get-involved/hacktoberfest/index-hacktoberfest.mdx
@@ -58,7 +58,9 @@ If you're looking for more repos to contribute to during Hacktoberfest, [check o
 
 ## Join us on Twitch and YouTube
 
-Documentation is often cited as a great way to get your feet wet with open source.  So to demystify the world of technical writing, we are hosting four live events with our documentation team - follow us on [Twitch](https://www.twitch.tv/redislabs) to get a reminder.  All sessions are at 9am PT / noon ET / 4pm UTC / 5pm UK / 7pm Israel:
+Documentation is often cited as a great way to get your feet wet with open source.  So to demystify the world of technical writing, we are hosting four live events with our documentation team.  Suze Shardlow, Developer Community Manager, is sitting down with Technical Writers Kaitlyn Michael, Rachel Elledge and Lance Leonard for a series of fireside chats.
+
+Follow us on [Twitch](https://www.twitch.tv/redislabs) to get a reminder or check out our [YouTube playlist](https://www.youtube.com/playlist?list=PL83Wfqi-zYZHj4wg4QiQMgyW5TBC8oAqQ) of all the past events.  All sessions are at 9am PT / noon ET / 4pm UTC / 5pm UK / 7pm Israel:
 
 ### Upcoming events
 * Friday 29th October: Fireside 1:1 - Suze Shardlow with Lance, Documentation Lead


### PR DESCRIPTION
Adds the YouTube links for the past documentation team fireside chats to the Hacktoberfest page.

- Closes #121.
- Closes #122.
