### PR TITLE
Makes the next/prev links configurable, defaults to on.

### DIFF
--- a/docs/get-involved/hacktoberfest/index-hacktoberfest.mdx
+++ b/docs/get-involved/hacktoberfest/index-hacktoberfest.mdx
@@ -4,6 +4,7 @@ title: Hacktoberfest 2021 at Redis
 sidebar_label: Hacktoberfest 2021
 slug: /hacktoberfest/
 authors: [suze,simon]
+useNextPrev: false
 ---
 
 

--- a/src/theme/DocItem/index.tsx
+++ b/src/theme/DocItem/index.tsx
@@ -170,9 +170,11 @@ function DocItem(props: Props): JSX.Element {
                 </div>
               </div>
             )}
-            <div className="margin-vert--lg">
-              <DocPaginator metadata={metadata} />
-            </div>
+            {(! DocContent.frontMatter.hasOwnProperty('useNextPrev') || DocContent.frontMatter.useNextPrev === true) && (
+              <div className="margin-vert--lg">
+                <DocPaginator metadata={metadata} />
+              </div>
+            )}
           </div>
         </div>
         {!hideTableOfContents && DocContent.toc && (


### PR DESCRIPTION
Makes the next/previous cards configurable... By default they are on, and you can turn them off by adding this to your document's front matter:

```yaml
useNextPrev: false
```

This preserves the current behaviour of all pages having these links, but allows us to override this for some where we don't want this (see the Hacktoberfest page for an example here).