### PR TITLE
Removed console log I left in by accident.

### DIFF
--- a/src/theme/DocItem/index.tsx
+++ b/src/theme/DocItem/index.tsx
@@ -27,7 +27,6 @@ import {
 
 function DocItem(props: Props): JSX.Element {
   const {siteConfig} = useDocusaurusContext();
-  console.log(siteConfig);
   const {url: siteUrl} = siteConfig;
   const {content: DocContent} = props;
   const {


### PR DESCRIPTION

Removes a `console.log` that I accidentally left in place while developing the show authors feature.  Sorry about that!