### PR TITLE
Removed announcement bar now Hacktoberfest is over.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -138,14 +138,14 @@ module.exports = {
       // Useful if you want to support a single color mode
       disableSwitch: false,
     },
-    announcementBar: {
-      id: 'redisconf20201cfp', // Any value that will identify this message.
-      content: '<p class="text">We\'re taking part in Hacktoberfest!</p> <a href="/hacktoberfest" class="btn">Join Us!</a>',
+    //announcementBar: {
+    //  id: 'redisconf20201cfp', // Any value that will identify this message.
+    //  content: '<p class="text">We\'re taking part in Hacktoberfest!</p> <a href="/hacktoberfest" class="btn">Join Us!</a>',
     //  content: '<p class="text"></p> <a href="https://www.youtube.com/c/Redisinc/playlists?view=50&sort=dd&shelf_id=1" target="_blank" rel="noopener" class="btn"></a>',
-      backgroundColor: '#fff', // Defaults to `#fff`.
-      textColor: '#000', // Defaults to `#000`.
-      isCloseable: true, // Defaults to `true`.
-    },
+    //  backgroundColor: '#fff', // Defaults to `#fff`.
+    //  textColor: '#000', // Defaults to `#000`.
+    //  isCloseable: true, // Defaults to `true`.
+    //},
   },
   presets: [
     [


### PR DESCRIPTION
Partially addresses #152 - removes the blue Hacktoberfest banner from the top of the site.