### PR TITLE
updating DataDog to Datadog

### DIFF
--- a/docs/explore/datadog/index-datadog.mdx
+++ b/docs/explore/datadog/index-datadog.mdx
@@ -1,6 +1,6 @@
 ---
 id: index-datadog
-title: Redis Enterprise Observability with DataDog
+title: Redis Enterprise Observability with Datadog
 sidebar_label: Redis Enterprise Observability with Datadog    
 slug: /explore/datadog
 authors: [ajeet,christian]


### PR DESCRIPTION
In the new blog post - https://developer.redis.com/explore/datadog/ - in the title, DataDog should be Datadog