### PR TITLE
Add AWS and Terraform Tutorial

### DIFF
--- a/docs/create/aws/terraform/index-terraform.mdx
+++ b/docs/create/aws/terraform/index-terraform.mdx
@@ -575,9 +575,8 @@ Destroy complete! Resources: 3 destroyed.
 ```
 
 
-### References:
-- https://redis.com/blog/provision-manage-redis-enterprise-cloud-hashicorp-terraform/
-- https://registry.terraform.io/providers/RedisLabs/rediscloud/latest
-- https://registry.terraform.io/modules/TobyHFerguson/Redislabs-Cloud-Account-Resources/aws/latest
-
-
+### Further References:
+- [Provision and Manage Redis Enterprise Cloud Anywhere with HashiCorp Terraform](https://redis.com/blog/provision-manage-redis-enterprise-cloud-hashicorp-terraform/)
+- [The HashiCorp Terraform Redis Enterprise Cloud provider](https://registry.terraform.io/providers/RedisLabs/rediscloud/latest)
+- [Azure Cache for Redis Enterprise using Terraform](https://developer.redis.com/create/azure/terraform-simple)
+- [Azure Cache for Redis Enterprise using Terraform with Private Link](https://developer.redis.com/create/azure/terraform-private-endpoint)


### PR DESCRIPTION
Modified the "Further References" links and kept it simple text with links rather than just links.