### PR TITLE
Add Docusaurus flag to show the last update time

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -214,6 +214,7 @@ module.exports = {
           routeBasePath: '/',
           path: 'docs',
           sidebarPath: require.resolve('./sidebars.js'),
+          showLastUpdateTime: true,
           editUrl:
           'https://github.com/redis-developer/redis-developer/edit/master/',
         },


### PR DESCRIPTION
Prior this PR, there was no way to tell if we were reading a new version of the page besides reading it entirely.

Now we'll get something like this:

![image](https://user-images.githubusercontent.com/13461315/148601214-a369c88c-bc0f-4730-9170-ecb8f20f9d8d.png)