### PR TITLE
Fixed the title for RediSearch Plugin

### DIFF
--- a/docs/explore/redisinsightv2/index-redisinsightv2.mdx
+++ b/docs/explore/redisinsightv2/index-redisinsightv2.mdx
@@ -47,8 +47,8 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
   <div class="col">
      <RedisCard
-        title="How To Use The RediSearch Browser Tool"
-        description="Perform Database Search and Analytics using the RediSearch Browser Tool in RedisInsight v2.0"
+        title="How To Use The RediSearch Plugin in RedisInsight v2.0"
+        description="Perform Database Search and Analytics using the RediSearch Plugin in RedisInsight v2.0"
         page="/explore/redisinsightv2/redisearch"
         />
  </div>

--- a/docs/explore/redisinsightv2/redisearch/index-redisearch.mdx
+++ b/docs/explore/redisinsightv2/redisearch/index-redisearch.mdx
@@ -1,7 +1,7 @@
 ---
 id: index-redisearch
-title: Perform Database Search and Analytics using the RediSearch Browser Tool in RedisInsight v2.0
-sidebar_label: Perform Database Search and Analytics using the RediSearch Browser Tool in RedisInsight v2.0
+title: Perform Database Search and Analytics using the RediSearch Plugin in RedisInsight v2.0
+sidebar_label: Perform Database Search and Analytics using the RediSearch Plugin in RedisInsight v2.0
 slug: /explore/redisinsightv2/redisearch
 authors: [ajeet]
 ---


### PR DESCRIPTION
RediSearch under RedisInsight is rightly called as "Plugin" rather than tool. Hence, this PR fixes it.