### PR TITLE
docs(rejson): python rootPath() -> root_path()

### DIFF
--- a/docs/howtos/redisjson/using-python/index-usingpython.mdx
+++ b/docs/howtos/redisjson/using-python/index-usingpython.mdx
@@ -70,7 +70,7 @@ jane = {
      'Location': "Chawton"
    }
 
-client.json().set('person:1', Path.rootPath(), jane)
+client.json().set('person:1', Path.root_path(), jane)
 
 result = client.json().get('person:1')
 print(result)
@@ -80,7 +80,7 @@ In the code above, we first connect to Redis and store a reference to the connec
 
 Next, we create a Python dictionary to represent a person object.
 
-And finally, we store the object in Redis using the `json().set()` method. The first argument, `person:1` is the name of the key that will reference the JSON. The second argument is a JSON path. We use `Path.rootPath()`, as this is a new object. Finally, we pass in the Python dictionary, which will be serialized to JSON.
+And finally, we store the object in Redis using the `json().set()` method. The first argument, `person:1` is the name of the key that will reference the JSON. The second argument is a JSON path. We use `Path.root_path()`, as this is a new object. Finally, we pass in the Python dictionary, which will be serialized to JSON.
 
 To retrieve the JSON object, we run `json().get()`, passing in the key. The result is a Python dictionary representing the JSON object stored in Redis.
 


### PR DESCRIPTION
In python, the docs tutorial(https://developer.redis.com/howtos/redisjson/using-python/) does not work for the hello world for rejson.

It appears to want `root_path()` instead of `rootPath()`

```python
python
Python 3.8.10 (default, Nov 26 2021, 20:14:08) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import redis
>>> from redis.commands.json.path import Path
>>> client = redis.Redis(host='localhost', port=6379, db=0)
>>> jane = {
...      'name': "Jane", 
...      'Age': 33, 
...      'Location': "Chawton"
...    }
>>> 
>>> client.json().set('person:1', Path.rootPath(), jane)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: type object 'Path' has no attribute 'rootPath'
>>> dir(Path)
['__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', 'root_path', 'strPath']
>>> client.json().set('person:1', Path.root_path(), jane)
True
```