### PR TITLE
Moved to a tab layout for the live events page...

### DIFF
--- a/docs/get-involved/redis-live/index-redis-live.mdx
+++ b/docs/get-involved/redis-live/index-redis-live.mdx
@@ -5,40 +5,57 @@ sidebar_label: Redis Live
 slug: /redis-live/
 custom_edit_url: null
 ---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 Redis Live hosts a variety of live-streamed content on [Twitch](https://www.twitch.tv/redisinc) and occasionally [YouTube](https://www.youtube.com/redisinc). Follow us to get notified when we go live. And, you know, like and subscribe.
 
-### Upcoming Streams
+<Tabs
+   defaultValue="upcoming"
+   values ={[
+    {label: 'Upcoming Events', value:  'upcoming'},
+    {label: 'Recurring Events', value: 'recurring'},
+    {label: 'Past Events', value: 'past'}
+   ]}>
+   <TabItem value="upcoming">
 
-Check out these upcoming streams:
+
+Check out our upcoming events:
 
 |        Date        |    Time     | Streamers                                             | Show                                                    |
 | :----------------: | :---------: | :---------------------------------------------------- | :------------------------------------------------------ |
-|   Friday, June 3   | 6:00 PM UTC | [Guy Royse][guy]                                      | Tracking Aircraft with Redis + Software-Defined Radio   |
-|  Friday, June 10   | 3:00 PM UTC | [Justin Castilla][justin], [Suze Shardlow][suze]      | Working with Redis Data Structures                      |
-|  Friday, June 10   | 6:00 PM UTC | [Guy Royse][guy]                                      | Working on Redis OM for Node.js                         |
-| Wednesday, June 15 | 4:00 PM UTC | [Simon Prickett][simon]                               | Up and Running with the RU102PY Redis University Course |
-| Wednesday, June 15 | 5:00 PM UTC | [Simon Prickett][simon]                               | Up and Running with the RU102JS Redis University Course |
-| Thursday, June 16  | 3:00 PM UTC | [Simon Prickett][simon], [Suze Shardlow][suze]        | Counting Things At Scale with Redis                     |
-| Thursday, June 23  | 6:00 PM UTC | [Justin Castilla][justin], [Savannah Norem][savannah] | Redis OM: Python + JSON + Search                        |
-|  Friday, June 24   | 6:00 PM UTC | [Guy Royse][guy]                                      | Graph, Graph, and Graph: Attorneys at Law               |
-|  Tuesday, June 28  | 3:00 PM UTC | [Simon Prickett][simon]                               | Up and Running with the RU102J Redis University Course  |
-| Wednesday, June 29 | 6:00 PM UTC | [Steve Lorello][steve]                                | Steve works on Redis OM .NET!                           |
 | Thursday, June 30  | 6:00 PM UTC | [Savannah Norem][savannah], [Guy Royse][guy]          | Comparing Sets, Bloom Filters, and Cuckoo Filters       |
 | Wednesday, July 6  | 6:00 PM UTC | [Steve Lorello][steve]                                | Real-Time Stock Analytics with Redis Stack and .NET     |
 |   Friday, July 8   | 6:00 PM UTC | [Brian Sam-Bodden][brian], [Guy Royse][guy]           | Extending Redis with Rust                               |
 | Wednesday, July 13 | 6:00 PM UTC | [Steve Lorello][steve]                                | Real-Time Stock Analytics with Redis Stack and .NET     |
 |  Friday, July 15   | 6:00 PM UTC | [Brian Sam-Bodden][brian], [Guy Royse][guy]           | Extending Redis with Rust                               |
 |  Friday, July 22   | 6:00 PM UTC | [Brian Sam-Bodden][brian], [Guy Royse][guy]           | Extending Redis with Rust                               |
-
-### Recurring Streams
-
+  </TabItem>
+  <TabItem value="recurring">
 Sometimes we're on the road speaking at in-person events or enjoying a well deserved vacation. But when we're not, here's our weekly streaming schedule:
 
-|    Day    |    Time    | Streamers              | Show                                                   |
-| :-------: | :--------: | :--------------------- | :----------------------------------------------------- |
-| Wednesday | 2:00 PM ET | [Steve Lorello][steve] | Coding with Steve                                      |
-|  Friday   | 2:00 PM ET | [Guy Royse][guy]       | Web, Whimsy, and Redis Stack: Random Projects with Guy |
+|    Day    |    Time    | Streamers              | Show                                                                                |
+| :-------: | :--------: | :--------------------- | :---------------------------------------------------------------------------------- |
+| Wednesday | 2:00 PM ET | [Steve Lorello][steve] | [Coding with Steve](https://twitch.tv/redisinc)                                     |
+|  Friday   | 2:00 PM ET | [Guy Royse][guy]       | [Web, Whimsy, and Redis Stack: Random Projects with Guy](https://twitch.tv/redisinc)|
+
+  </TabItem>
+  <TabItem value="past">
+
+Past events:
+
+|        Date        |    Time     | Streamers                                             | Show                                                    |
+| :----------------: | :---------: | :---------------------------------------------------- | :------------------------------------------------------ |
+| Wednesday, June 29 | 6:00 PM UTC | [Steve Lorello][steve]                                | Steve works on Redis OM .NET!                           |
+|  Tuesday, June 28  | 3:00 PM UTC | [Simon Prickett][simon]                               | Up and Running with the RU102J Redis University Course  |
+|  Friday, June 24   | 6:00 PM UTC | [Guy Royse][guy]                                      | Graph, Graph, and Graph: Attorneys at Law               |
+| Thursday, June 23  | 6:00 PM UTC | [Justin Castilla][justin], [Savannah Norem][savannah] | [Redis OM: Python + JSON + Search](https://www.youtube.com/watch?v=ZP2j7bmWfmU)|
+| Thursday, June 16  | 3:00 PM UTC | [Simon Prickett][simon], [Justin Castilla][justin]    | [Counting Things At Scale with Redis](https://www.youtube.com/watch?v=FAJXq5Qqc0Y)|
+| Wednesday, June 15 | 5:00 PM UTC | [Simon Prickett][simon]                               | Up and Running with the RU102JS Redis University Course |
+| Wednesday, June 15 | 4:00 PM UTC | [Simon Prickett][simon]                               | Up and Running with the RU102PY Redis University Course |
+|  Friday, June 10   | 6:00 PM UTC | [Guy Royse][guy]                                      | Working on Redis OM for Node.js                         |
+|  Friday, June 10   | 3:00 PM UTC | [Justin Castilla][justin], [Suze Shardlow][suze]      | Working with Redis Data Structures                      |
+|   Friday, June 3   | 6:00 PM UTC | [Guy Royse][guy]                                      | Tracking Aircraft with Redis + Software-Defined Radio   |
 
 <!-- Links -->
 
@@ -49,3 +66,5 @@ Sometimes we're on the road speaking at in-person events or enjoying a well dese
 [simon]: https://twitter.com/simon_prickett
 [steve]: https://twitter.com/slorello
 [suze]: https://twitter.com/SuzeShardlow
+  </TabItem>
+</Tabs>


### PR DESCRIPTION
Moved the live events page to a 3 tab layout:

* Upcoming: Events in date order.
* Recurring: Ongoing weekly / monthly events.
* Past: Events that have passed, most recent first.  I've linked to the YouTube video where available.

Question... should the past events that went out only on Twitch link to the video's page on Twitch?  Then, when these expire on Twitch I guess Twitch will redirect them to our channel's home page.

Question... should upcoming events also link to Twitch and YouTube where we have URLs for those?

Here's what it looks like...



https://user-images.githubusercontent.com/94062/176696709-fc193122-f237-4117-bdfd-3e4cd53305a9.mov


