### PR TITLE
Moved 27 July stream to past, added video link.

### DIFF
--- a/docs/get-involved/redis-live/index-redis-live.mdx
+++ b/docs/get-involved/redis-live/index-redis-live.mdx
@@ -24,7 +24,6 @@ Check out our upcoming events:
 
 |        Date          |    Time     | Streamers                                             | Show                                                               |
 | :------------------: | :---------: | :---------------------------------------------------- | :----------------------------------------------------------------- |
-|  Wednesday, July 27  | 6:00 PM UTC | [Steve Lorello][steve]                                | Steve Works on cli.redis.io                                        |
 |  Thursday, July 28   | 3:00 PM UTC | [Simon Prickett][simon]                               | Up and Running with RU203: Querying, Indexing and Full-Text Search |
 |   Friday, July 29    | 4:00 PM UTC | [Savannah Norem][norem], [Simon Prickett][simon]      | First Steps to Open Source Contribution                            |
 |   Friday, July 29    | 6:00 PM UTC | [Guy Royse][guy]                                      | Web, Whimsy, and Redis Stack: Random Projects with Guy             |
@@ -52,6 +51,7 @@ Past events:
 
 |        Date          |    Time     | Streamers                                             | Show                                                                     |
 | :------------------: | :---------: | :---------------------------------------------------- | :----------------------------------------------------------------------- |
+|  Wednesday, July 27  | 6:00 PM UTC | [Steve Lorello][steve]                                | [Steve Works on cli.redis.io][7]                                         |
 |   Tuesday, July 26   | 6:00 PM UTC | [Savannah Norem][norem]                               | [savannah_streams_in_snake_case - Probabilistic Data Structures][6]      |
 |  Wednesday, July 20  | 6:00 PM UTC | [Steve Lorello][steve]                                | [Steve Works on cli.redis.io][4]                                         |
 |   Friday, July 15    | 6:00 PM UTC | [Guy Royse][guy]                                      | [Exploring Bun and Node Redis][3]                                        |
@@ -89,6 +89,7 @@ Past events:
 [yt]: https://www.youtube.com/redisinc
 
 <!-- Links to specific videos -->
+[7]: https://www.youtube.com/watch?v=68FDI5GlMIU
 [6]: https://www.youtube.com/watch?v=_TGJSXZvLT8
 [5]: https://www.youtube.com/watch?v=q2UOkQmIo9Q
 [4]: https://www.youtube.com/watch?v=LV2Ax0Y8Kxk


### PR DESCRIPTION
Move Steve's stream to the past tab, add the youtube link for it.