### PR TITLE
Changed image rendered as snippet to an actual img

### DIFF
--- a/docs/create/rediscloud/index-recloud.mdx
+++ b/docs/create/rediscloud/index-recloud.mdx
@@ -98,21 +98,19 @@ Click "Get specific fields" to access part of a stored JSON document as shown in
 - [Connecting to the database using RedisInsight](/explore/redisinsight/)
 - [How to list & search Movies database using Redisearch](/howtos/moviesdatabase/getting-started/)
 
-##
 
-<div>
-  <a
-    href="https://launchpad.redis.com"
-    target="_blank"
-    rel="noopener"
-    className="link">
 
-    <img
-      src="/img/launchpad.png"
-      className="thumb"
-      loading="lazy"
-      alt="Redis Launchpad"
-    />
+<a
+  href="https://launchpad.redis.com"
+  target="_blank"
+  rel="noopener"
+  className="link">
 
-  </a>
-</div>
+  <img
+    src="/images/launchpad.png"
+    className="thumb"
+    loading="lazy"
+    alt="Redis Launchpad"
+  />
+
+</a>


### PR DESCRIPTION
For some reason, wrapping the last image in a DIV makes it to be rendered as a code snippet, removing the wrapper, makes it show the image correctly.