### PR TITLE
Fixes launchpad image static path.

### DIFF
--- a/docs/create/cloud/rediscloud/index-recloud.mdx
+++ b/docs/create/cloud/rediscloud/index-recloud.mdx
@@ -62,19 +62,17 @@ Click "Activate" and wait for few seconds till it gets activated. Once fully act
 
 ##
 
-<div>
-  <a
-    href="https://launchpad.redis.com"
-    target="_blank"
-    rel="noopener"
-    className="link">
+<a
+  href="https://launchpad.redis.com"
+  target="_blank"
+  rel="noopener"
+  className="link">
 
-    <img
-      src="/img/launchpad.png"
-      className="thumb"
-      loading="lazy"
-      alt="Redis Launchpad"
-    />
+  <img
+    src="/img/launchpad.png"
+    className="thumb"
+    loading="lazy"
+    alt="Redis Launchpad"
+  />
 
-  </a>
-</div>
+</a>

--- a/docs/create/rediscloud/index-recloud.mdx
+++ b/docs/create/rediscloud/index-recloud.mdx
@@ -107,7 +107,7 @@ Click "Get specific fields" to access part of a stored JSON document as shown in
   className="link">
 
   <img
-    src="/images/launchpad.png"
+    src="/img/launchpad.png"
     className="thumb"
     loading="lazy"
     alt="Redis Launchpad"

--- a/docs/create/rediscloud/index-recloud.mdx
+++ b/docs/create/rediscloud/index-recloud.mdx
@@ -98,21 +98,19 @@ Click "Get specific fields" to access part of a stored JSON document as shown in
 - [Connecting to the database using RedisInsight](/explore/redisinsight/)
 - [How to list & search Movies database using Redisearch](/howtos/moviesdatabase/getting-started/)
 
-##
 
-<div>
-  <a
-    href="https://launchpad.redis.com"
-    target="_blank"
-    rel="noopener"
-    className="link">
 
-    <img
-      src="/img/launchpad.png"
-      className="thumb"
-      loading="lazy"
-      alt="Redis Launchpad"
-    />
+<a
+  href="https://launchpad.redis.com"
+  target="_blank"
+  rel="noopener"
+  className="link">
 
-  </a>
-</div>
+  <img
+    src="/images/launchpad.png"
+    className="thumb"
+    loading="lazy"
+    alt="Redis Launchpad"
+  />
+
+</a>


### PR DESCRIPTION
This was rendering as markdown not an image... See #383 for a previous attempt to fix this that didn't work for me.  I'll raise a separate issue to fix numerous other instance of this.

Test locally:

```
yarn start
```

Then visit `http://localhost:3000/create/cloud/rediscloud` and ensure that the launchpad image at the end renders and is a link to the launchpad.