### PR TITLE
Moved Aug 3 stream to past, adds link.

### DIFF
--- a/docs/get-involved/redis-live/index-redis-live.mdx
+++ b/docs/get-involved/redis-live/index-redis-live.mdx
@@ -24,7 +24,6 @@ Check out our upcoming events:
 
 |        Date          |    Time     | Streamers                                             | Show                                                               |
 | :------------------: | :---------: | :---------------------------------------------------- | :----------------------------------------------------------------- |
-| Wednesday, August 3  | 6:00 PM UTC | [Steve Lorello][steve]                                | Steve Works on Redis OM .NET                                       |
 |  Friday, August 5    | 9:30 AM UTC | [Simon Prickett][simon]                               | IoT with Redis: Introduction                                       |
 |  Tuesday, August 9   | 6:00 PM UTC | [Savannah Norem][norem]                               | savannah_streams_in_snake_case                                     |
 | Wednesday, August 10 | 6:00 PM UTC | [Steve Lorello][steve]                                | Coding with Steve                                                  |
@@ -48,6 +47,7 @@ Past events:
 
 |        Date          |    Time     | Streamers                                             | Show                                                                     |
 | :------------------: | :---------: | :---------------------------------------------------- | :----------------------------------------------------------------------- |
+| Wednesday, August 3  | 6:00 PM UTC | [Steve Lorello][steve]                                | [Steve Works on Redis OM .NET][10]                                       |
 |  Tuesday, August 2   | 6:00 PM UTC | [Savannah Norem][norem]                               | [savannah_streams_in_snake_case][9]                                      |
 |   Friday, July 29    | 4:00 PM UTC | [Savannah Norem][norem], [Simon Prickett][simon]      | [First Steps to Open Source Contribution][8]                             |
 |  Thursday, July 28   | 3:00 PM UTC | [Simon Prickett][simon]                               | Up and Running with RU203: Querying, Indexing and Full-Text Search       |
@@ -89,6 +89,7 @@ Past events:
 [yt]: https://www.youtube.com/redisinc
 
 <!-- Links to specific videos -->
+[10]: https://www.youtube.com/watch?v=_HyV2OkMUCw
 [9]: https://www.youtube.com/watch?v=y5VXze8xtEA
 [8]: https://www.youtube.com/watch?v=SnKeNYJ_qsQ
 [7]: https://www.youtube.com/watch?v=68FDI5GlMIU


### PR DESCRIPTION
Moves Steve's Aug 3 stream to the past tab and adds a YouTube link for it.