### PR TITLE
Cleaned up live events page.

### DIFF
--- a/docs/get-involved/redis-live/index-redis-live.mdx
+++ b/docs/get-involved/redis-live/index-redis-live.mdx
@@ -24,8 +24,6 @@ Check out our upcoming events:
 
 |        Date          |    Time     | Streamers                                             | Show                                                               |
 | :------------------: | :---------: | :---------------------------------------------------- | :----------------------------------------------------------------- |
-| Wednesday, August 10 | 6:00 PM UTC | [Steve Lorello][steve]                                | Coding with Steve                                                  |
-| Thursday, August 11  | 9:00 AM UTC | [Simon Prickett][simon]                               | Simon's Things on Thursdays                                        |
 |  Friday, August 12   | 6:00 PM UTC | [Guy Royse][guy]                                      | Web, Whimsy, and Redis Stack: Random Projects with Guy             |
 
   </TabItem>
@@ -47,6 +45,7 @@ Past events:
 
 |        Date          |    Time     | Streamers                                             | Show                                                                     |
 | :------------------: | :---------: | :---------------------------------------------------- | :----------------------------------------------------------------------- |
+| Wednesday, August 10 | 6:00 PM UTC | [Steve Lorello][steve]                                | [Coding with Steve][13]                                                  |
 |  Tuesday, August 9   | 6:00 PM UTC | [Savannah Norem][norem]                               | [savannah_streams_in_snake_case][12]                                     |
 |  Friday, August 5    | 9:30 AM UTC | [Simon Prickett][simon]                               | [IoT with Redis: Introduction][11]                                       |
 | Wednesday, August 3  | 6:00 PM UTC | [Steve Lorello][steve]                                | [Steve Works on Redis OM .NET][10]                                       |
@@ -91,6 +90,7 @@ Past events:
 [yt]: https://www.youtube.com/redisinc
 
 <!-- Links to specific videos -->
+[13]: https://www.youtube.com/watch?v=eSnmtf3zcNc
 [12]: https://www.youtube.com/watch?v=w1S-ZuCJc2Y
 [11]: https://www.youtube.com/watch?v=1F2nmm2jBjA
 [10]: https://www.youtube.com/watch?v=_HyV2OkMUCw


### PR DESCRIPTION
Move Steve's event to the past, add video link for it.  Delete Simon's failed Aug 11 livestream.