### PR TITLE
Moved Aug 23 stream to past, added video.

### DIFF
--- a/docs/get-involved/redis-live/index-redis-live.mdx
+++ b/docs/get-involved/redis-live/index-redis-live.mdx
@@ -24,7 +24,6 @@ Check out our upcoming events:
 
 |        Date           |    Time     | Streamers                 | Show                                                               |
 | :-------------------: | :---------: | :------------------------ | :----------------------------------------------------------------- |
-| Tuesday, August 23    | 6:00 PM UTC | [Savannah Norem][norem]   | savannah_streams_in_snake_case: Stream a Little Stream - Episode 1 |
 | Wednesday, August 24  | 6:00 PM UTC | [Steve Lorello][steve]    | Coding with Steve: Redis OM .NET - Episode 5                       |
 | Thursday, August 25   | 9:30 AM UTC | [Simon Prickett][simon]   | Simon's Things on Thursdays - Episode 2                            |
 | Friday, August 26     | 6:00 PM UTC | [Guy Royse][guy]          | Web, Whimsy, and Redis Stack: Redis MUD - Episode 2                |
@@ -52,6 +51,7 @@ Past events:
 
 |        Date          |    Time     | Streamers                                             | Show                                                                     |
 | :------------------: | :---------: | :---------------------------------------------------- | :----------------------------------------------------------------------- |
+| Tuesday, August 23   | 6:00 PM UTC | [Savannah Norem][norem]                               | [savannah_streams_in_snake_case: Stream a Little Stream - Episode 1][17] |
 | Thursday, August 18  | 9:30 AM UTC | [Simon Prickett][simon]                               | [Simon's Things on Thursdays][16]                                        |
 | Tuesday, August 16   | 6:00 PM UTC | [Savannah Norem][norem]                               | [savannah_streams_in_snake_case][15]                                     |
 | Friday, August 12    | 6:00 PM UTC | [Guy Royse][guy]                                      | [Web, Whimsy, and Redis Stack: Random Projects with Guy][14]             |
@@ -100,6 +100,7 @@ Past events:
 [yt]: https://www.youtube.com/redisinc
 
 <!-- Links to specific videos -->
+[17]: https://www.youtube.com/watch?v=QDfGI6jpwqA
 [16]: https://www.youtube.com/watch?v=uyjAFP73ttI
 [15]: https://www.youtube.com/watch?v=cFnBfsbyhvU
 [14]: https://www.youtube.com/watch?v=FfD2nmCrocI


### PR DESCRIPTION
Adds video for 23 Aug live stream, moved it to past tab.  I also added it to the relevant playlists on YouTube and deleted a couple of spam comments there.