### PR TITLE
Updated for Steve 7 Sept and Simon 8 Sept streams adds Simon Sept 22 stream.

### DIFF
--- a/docs/get-involved/redis-live/index-redis-live.mdx
+++ b/docs/get-involved/redis-live/index-redis-live.mdx
@@ -26,8 +26,9 @@ Check out our upcoming events:
 | :---------------------: | :---------: | :---------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------- |
 | Thursday, September 8   | 3:00 PM UTC | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [Weekly Redis University Office Hours][officehrs]                  |
 | Friday, September 9     | 5:00 PM UTC | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [This Week On Discord][twitch]                                     |
-| Thursday, September 15  | 3:00 PM UTC | [Savannah Norem][norem] and [Justin Castilla][justin]  | [Weekly Redis University Office Hours][officehrs]  |
-| Friday, September 16    | 5:00 PM UTC | [Savannah Norem][norem] and [Justin Castilla][justin]  | [This Week On Discord][twitch]                                     |
+| Thursday, September 15  | 3:00 PM UTC | [Savannah Norem][norem] and [Justin Castilla][justin]                                                 | [Weekly Redis University Office Hours][officehrs]                  |
+| Friday, September 16    | 5:00 PM UTC | [Savannah Norem][norem] and [Justin Castilla][justin]                                                 | [This Week On Discord][twitch]                                     |
+| Thursday, September 22  | 9:30 AM UTC | [Simon Prickett][simon]                                                                               | Simon's Things on Thursdays - Raspberry Pi Pico W - Episode 2      |
 | Thursday, September 22  | 3:00 PM UTC | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [Weekly Redis University Office Hours][officehrs]                  |
 | Friday, September 23    | 5:00 PM UTC | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [This Week On Discord][twitch]                                     |
 | Thursday, September 29  | 3:00 PM UTC | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [Weekly Redis University Office Hours][officehrs]                  |

--- a/docs/get-involved/redis-live/index-redis-live.mdx
+++ b/docs/get-involved/redis-live/index-redis-live.mdx
@@ -24,7 +24,6 @@ Check out our upcoming events:
 
 |        Date             |    Time     | Streamers                                                                                             | Show                                                               |
 | :---------------------: | :---------: | :---------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------- |
-| Thursday, September 8   | 9:30 AM UTC | [Simon Prickett][simon]                                                                               | Simon's Things on Thursdays - New IoT Project                      |
 | Thursday, September 8   | 3:00 PM UTC | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [Weekly Redis University Office Hours][officehrs]                  |
 | Friday, September 9     | 5:00 PM UTC | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [This Week On Discord][twitch]                                     |
 | Thursday, September 15  | 3:00 PM UTC | [Savannah Norem][norem] and [Justin Castilla][justin]  | [Weekly Redis University Office Hours][officehrs]  |
@@ -55,6 +54,8 @@ Past events:
 
 |         Date          |    Time     | Streamers                                                                                             | Show                                                                     |
 | :-------------------: | :---------: | :---------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------- |
+| Thursday, September 8 | 9:30 AM UTC | [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays - Raspberry Pi Pico W - Episode 1][27]      |
+| Wednesday, September 7| 6:00 PM UTC | [Steve Lorello][steve]                                                                                | [Coding with Steve: Redis OM .NET - Episode 7][26]
 | Tuesday, September 6  | 6:00 PM UTC | [Savannah Norem][norem]                                                                               | [savannah_streams_in_snake_case: Stream a Little Stream - Episode 3][25] |
 | Friday, September 2   | 6:00 PM UTC | [Guy Royse][guy]                                                                                      | [Web, Whimsy, and Redis Stack: Redis MUD - Episode 3][24]                |
 | Friday, September 2   | 5:00 PM UTC | [Suze Shardlow][Suze], [Savannah Norem][norem] and [Simon Prickett][simon]                            | [This Week On Discord][23]                                               |
@@ -114,6 +115,8 @@ Past events:
 [officehrs]: https://discord.com/channels/697882427875393627/981667564570706000
 
 <!-- Links to specific videos -->
+[27]: https://www.youtube.com/watch?v=8Q3jK5CAfNQ
+[26]: https://www.youtube.com/watch?v=_-YmsyWUQNo
 [25]: https://www.youtube.com/watch?v=gUTqalK2h94
 [24]: https://www.youtube.com/watch?v=Qo3tuD8fTNI
 [23]: https://www.youtube.com/watch?v=hmmkLzU_ymA


### PR DESCRIPTION
Moved Simon's 8th Sept stream to past, added video link.  Added Steve's 7th Sept stream to past (it wasn't in upcoming so didn't remove it from there).  Also adds Simon's Sept 22 stream.