### PR TITLE
fix: corrected launchpad image in redis-on-docker index

### DIFF
--- a/docs/create/docker/redis-on-docker/index-redis-on-docker.mdx
+++ b/docs/create/docker/redis-on-docker/index-redis-on-docker.mdx
@@ -169,13 +169,11 @@ For example, here’s how to use the `REDIS_ARGS` environment variable to pass t
     target="_blank"
     rel="noopener"
     className="link">
-
     <img
       src="/img/launchpad.png"
       className="thumb"
       loading="lazy"
       alt="Redis Launchpad"
     />
-
   </a>
 </div>


### PR DESCRIPTION
Fixing the image markup for at the bottom of https://developer.redis.com/create/docker/redis-on-docker/

| Before | After |
| :--: | :--: |
| ![image](https://user-images.githubusercontent.com/45119518/191476100-03c3676a-ed84-45e9-8f26-995a13c73b2b.png)| ![image](https://user-images.githubusercontent.com/45119518/191476131-1e08d42e-98f6-47a3-9c15-f657fb233aaa.png) |