### PR TITLE
Update FastAPI tutorial doc

### DIFF
--- a/docs/develop/python/fastapi/index-fastapi.mdx
+++ b/docs/develop/python/fastapi/index-fastapi.mdx
@@ -113,9 +113,9 @@ IsBitcoinLit includes a `pyproject.toml` file that Poetry uses to manage the pro
 
 Once you have a `pyproject.toml` file, and assuming you already added FastAPI and any other necessary dependencies, you could add aioredis-py to your project like this:
 
-    	$ poetry add aioredis-py@2.0.0b1
+    	$ poetry add aioredis@2.0.0
 
-**NOTE**: This tutorial uses a beta version of aioredis-py 2.0. The 2.0 version of aioredis-py features an API that matches the most popular synchronous Redis client for Python, [redis-py](https://github.com/andymccurdy/redis-py).
+**NOTE**: This tutorial uses aioredis-py 2.0. The 2.0 version of aioredis-py features an API that matches the most popular synchronous Redis client for Python, [redis-py](https://github.com/andymccurdy/redis-py).
 
 The aioredis-py client is now installed. Time to write some code!
 


### PR DESCRIPTION
- `aioredis-py` 2.0.0 is not a beta version anymore (https://github.com/aio-libs/aioredis-py/releases)
- update `poetry add aioredis-py` to `poetry add aioredis` (https://aioredis.readthedocs.io/en/latest/getting-started/#installation)
