### PR TITLE
Hotfix: end maven's version tag on Java RedisJSON documentation example

### DIFF
--- a/docs/howtos/redisjson/using-java/index-usingjava.mdx
+++ b/docs/howtos/redisjson/using-java/index-usingjava.mdx
@@ -25,7 +25,7 @@ You'll need to add Jedis to your Java project. If you're using [Maven](https://m
 <dependency>
     <groupId>redis.clients</groupId>
     <artifactId>jedis</artifactId>
-    <version>4.0.0<version>
+    <version>4.0.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Simple adjust to fix maven's version on example:

```diff
<dependency>
            <groupId>redis.clients</groupId>
            <artifactId>jedis</artifactId>
          -<version>4.0.0<version>
          +<version>4.0.0</version>
</dependency>
```