### PR TITLE
Moved Nov 21 livestream to past tab.

### DIFF
--- a/docs/get-involved/redis-live/index-redis-live.mdx
+++ b/docs/get-involved/redis-live/index-redis-live.mdx
@@ -24,7 +24,6 @@ Check out our upcoming events:
 
 |        Date             |    Time     | Streamers                                                                                             | Show                                                                                                 |
 | :---------------------: | :---------: | :---------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
-| Monday, November 21     | 3:00 PM PST | [Justin Castilla][justin]                                                                             | [Do birds dream in JSON?][twitch]                                                                    |
 | Thursday, November 24   | 10:30 AM UTC| [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays: Synchronized Counting with Keyspace Notifications - Episode 2][twitch] |
 | Thursday, November 24   | 4:00 PM UTC | [Suze Shardlow][Suze] and [Simon Prickett][simon]                                                     | [Redis University Office Hours][officehrs]                                                           |
 | Friday, November 25     | 6:00 PM UTC | [Suze Shardlow][Suze] and [Simon Prickett][simon]                                                     | [This Week On Discord][twitch]                                                                       |
@@ -58,16 +57,17 @@ Past events:
 
 |         Date           |    Time      | Streamers                                                                                             | Show                                                                                             |
 | :-------------------:  | :----------: | :---------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------- |
+| Monday, November 21    | 3:00 PM PST  | [Justin Castilla][justin]                                                                             | [Do birds dream in JSON? - Episode 3][56]                                                        |
 | Friday, November 18    | 6:00 PM UTC  | [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin]                        | [This Week On Discord][55]                                                                       |
 | Thursday, November 17  | 4:00 PM UTC  | [Justin Castilla][justin]                                                                             | [Redis University Office Hours][officehrs]                                                       |
 | Thursday, November 17  | 10:30 AM UTC | [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays: Synchronized Counting with Keyspace Notifications - Episode 1][54] |
-| Monday, November 14    | 3:00 PM PST  | [Justin Castilla][justin]                                                                             | [Do birds dream in JSON?][53]                                                                    |
+| Monday, November 14    | 3:00 PM PST  | [Justin Castilla][justin]                                                                             | [Do birds dream in JSON? - Episode 2][53]                                                        |
 | Thursday, November 10  | 6:00 PM UTC  | [Savannah Norem][norem] and [Justin Castilla][justin]                                                 | [This Week On Discord][52]                                                                       |
 | Thursday, November 10  | 4:00 PM UTC  | [Savannah Norem][norem] and [Justin Castilla][justin]                                                 | [Redis University Office Hours][officehrs]                                                       |
 | Friday, November 4     | 5:00 PM UTC  | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [This Week On Discord][51]                                                                       |
 | Thursday, November 3   | 3:00 PM UTC  | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [Redis University Office Hours][officehrs]                                                       |
 | Thursday, November 3   | 9:30 AM UTC  | [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays - Cheerlights with MQTT and Redis Streams][50]                      |
-| Monday, October 31     | 10:00 PM UTC | [Justin Castilla][justin]                                                                             | [Do birds dream in JSON?][49]                                                                    |
+| Monday, October 31     | 10:00 PM UTC | [Justin Castilla][justin]                                                                             | [Do birds dream in JSON? - Episode 1][49]                                                        |
 | Friday, October 28     | 5:00 PM UTC  | [Suze Shardlow][Suze], [Simon Prickett][simon] and [Justin Castilla][justin]                          | [This Week On Discord][48]                                                                       |
 | Thursday, October 27   | 3:00 PM UTC  | [Suze Shardlow][Suze] and [Simon Prickett][simon]                                                     | [Weekly Redis University Office Hours][officehrs]                                                |
 | Thursday, October 27   | 9:30 AM UTC  | [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays - Raspberry Pi Pico W - Episode 5][47]                              |
@@ -158,6 +158,7 @@ Past events:
 [officehrs]: https://discord.com/channels/697882427875393627/981667564570706000
 
 <!-- Links to specific videos -->
+[56]: https://www.youtube.com/watch?v=SiJfrsSJBHg
 [55]: https://www.youtube.com/watch?v=xbX7tnHx7WA
 [54]: https://www.youtube.com/watch?v=NJyR8FKb9aI
 [53]: https://www.youtube.com/watch?v=tYhHUkuIugU


### PR DESCRIPTION
Moved Nov 21 livestream to past tab, added video link and episode numbers.