### PR TITLE
adds RU204: LIVE to the schedule

### DIFF
--- a/docs/get-involved/redis-live/index-redis-live.mdx
+++ b/docs/get-involved/redis-live/index-redis-live.mdx
@@ -24,17 +24,21 @@ Check out our upcoming events:
 
 |        Date             |    Time     | Streamers                                                                                             | Show                                                                                                 |
 | :---------------------: | :---------: | :---------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
-| Monday, November 21     | 3:00 PM PST | [Justin Castilla][justin]                                                                             | [Do birds dream in JSON?][twitch]                                                                    |
-| Thursday, November 24   | 10:30 AM UTC| [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays: Synchronized Counting with Keyspace Notifications - Episode 2][twitch] |
-| Thursday, November 24   | 4:00 PM UTC | [Suze Shardlow][Suze] and [Simon Prickett][simon]                                                     | [Redis University Office Hours][officehrs]                                                           |
+| Thursday, November 24   | 10:30 AM UTC| [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays: Synchronized Counting with Keyspace Notifications - Episode 2][twitch]  |
+| Thursday, November 24   | 4:00 PM UTC | [Suze Shardlow][Suze] and [Simon Prickett][simon]                                                     | [Redis University Office Hours][officehrs]                                                             |
 | Friday, November 25     | 6:00 PM UTC | [Suze Shardlow][Suze] and [Simon Prickett][simon]                                                     | [This Week On Discord][twitch]                                                                       |
 | Monday, November 28     | 3:00 PM PST | [Justin Castilla][justin]                                                                             | [Do birds dream in JSON?][twitch]                                                                    |
-| Thursday, December 1    | 4:00 PM UTC | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [Redis University Office Hours][officehrs]                                                           |
+| Thursday, December 1    | 4:00 PM UTC | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [Redis University Office Hours][officehrs]                                                             |
 | Friday, December 2      | 6:00 PM UTC | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [This Week On Discord][twitch]                                                                       |
+| Monday, December 5      | 12:00 PM PST | [Savannah Norem][norem], [Justin Castilla][justin]                                                   | [RU204: Live][twitch]                                                                                |
 | Monday, December 5      | 3:00 PM PST | [Justin Castilla][justin]                                                                             | [Do birds dream in JSON?][twitch]                                                                    |
-| Thursday, December 8    | 4:00 PM UTC | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [Redis University Office Hours][officehrs]                                                           |
+| Tuesday, December 6     | 12:00 PM PST | [Savannah Norem][norem], [Justin Castilla][justin]                                                   | [RU204: Live][twitch]                                                                                |
+| Wednesday, December 7   | 12:00 PM PST | [Savannah Norem][norem], [Justin Castilla][justin]                                                   | [RU204: Live][twitch]                                                                                |
+| Thursday, December 8    | 4:00 PM UTC | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [Redis University Office Hours][officehrs]                                                             |
+| Thursday, December 8    | 12:00 PM PST | [Savannah Norem][norem], [Justin Castilla][justin]                                                   | [RU204: Live][twitch]                                                                                |
 | Friday, December 9      | 6:00 PM UTC | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [This Week On Discord][twitch]                                                                       |
-| Thursday, December 15   | 4:00 PM UTC | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [Redis University Office Hours][officehrs]                                                           |
+| Friday, December 9      | 12:00 PM PST | [Savannah Norem][norem], [Justin Castilla][justin]                                                   | [RU204: Live][twitch]                                                                                |
+| Thursday, December 15   | 4:00 PM UTC | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [Redis University Office Hours][officehrs]                                                             |
 | Friday, December 16     | 6:00 PM UTC | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [This Week On Discord][twitch]                                                                       |
 
 
@@ -58,6 +62,7 @@ Past events:
 
 |         Date           |    Time      | Streamers                                                                                             | Show                                                                                             |
 | :-------------------:  | :----------: | :---------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------- |
+| Monday, November 21     | 3:00 PM PST | [Justin Castilla][justin]                                                                             | [Do birds dream in JSON?][56]                                                                    |
 | Friday, November 18    | 6:00 PM UTC  | [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin]                        | [This Week On Discord][55]                                                                       |
 | Thursday, November 17  | 4:00 PM UTC  | [Justin Castilla][justin]                                                                             | [Redis University Office Hours][officehrs]                                                       |
 | Thursday, November 17  | 10:30 AM UTC | [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays: Synchronized Counting with Keyspace Notifications - Episode 1][54] |
@@ -158,6 +163,7 @@ Past events:
 [officehrs]: https://discord.com/channels/697882427875393627/981667564570706000
 
 <!-- Links to specific videos -->
+[56]: https://www.youtube.com/watch?v=SiJfrsSJBHg
 [55]: https://www.youtube.com/watch?v=xbX7tnHx7WA
 [54]: https://www.youtube.com/watch?v=NJyR8FKb9aI
 [53]: https://www.youtube.com/watch?v=tYhHUkuIugU


### PR DESCRIPTION
Adds RU204 LIVE to twitch schedule. Dates are solid but time can change to whatever is convenient. 