### PR TITLE
Fix readFileSync options parameter

### DIFF
--- a/docs/guides/security/how-to-use-tls-with-redis-enterprise/how-to-use-ssl-tls-with-redis-enterprise.mdx
+++ b/docs/guides/security/how-to-use-tls-with-redis-enterprise/how-to-use-ssl-tls-with-redis-enterprise.mdx
@@ -205,13 +205,13 @@ import fs from 'fs';
 const ssl = {
   key: fs.readFileSync(
     '../certificates/client_key_app_001.pem',
-    (encoding = 'ascii'),
+    {encoding: 'ascii'},
   ),
   cert: fs.readFileSync(
     '../certificates/client_cert_app_001.pem',
-    (encoding = 'ascii'),
+    {encoding: 'ascii'},
   ),
-  ca: [fs.readFileSync('../certificates/proxy_cert.pem', (encoding = 'ascii'))],
+  ca: [fs.readFileSync('../certificates/proxy_cert.pem', {encoding: 'ascii'})],
   checkServerIdentity: () => {
     return null;
   },

--- a/docs/howtos/security/tls.mdx
+++ b/docs/howtos/security/tls.mdx
@@ -209,13 +209,13 @@ var fs = require('fs');
 var ssl = {
   key: fs.readFileSync(
     '../certificates/client_key_app_001.pem',
-    (encoding = 'ascii'),
+    {encoding: 'ascii'},
   ),
   cert: fs.readFileSync(
     '../certificates/client_cert_app_001.pem',
-    (encoding = 'ascii'),
+    {encoding: 'ascii'},
   ),
-  ca: [fs.readFileSync('../certificates/proxy_cert.pem', (encoding = 'ascii'))],
+  ca: [fs.readFileSync('../certificates/proxy_cert.pem', {encoding: 'ascii'})],
   checkServerIdentity: () => {
     return null;
   },


### PR DESCRIPTION
`readFileSync` accepts an object or a string as the second parameter. The examples use `(encoding = 'ascii')` which assigns `ascii` as a string to `encoding` variable and then returns its value. Therefore, it is semantically correct but I think the intent here was to pass an object instead of assigning the string to a variable.