### PR TITLE
Updating json example to use the json v2 root path

### DIFF
--- a/docs/howtos/redisjson/using-python/index-usingpython.mdx
+++ b/docs/howtos/redisjson/using-python/index-usingpython.mdx
@@ -100,7 +100,7 @@ jane = {
      'Location': "Chawton"
    }
 
-client.json().set('person:1', Path.root_path(), jane)
+client.json().set('person:1', '$', jane)
 
 result = client.json().get('person:1')
 print(result)
@@ -110,7 +110,7 @@ In the code above, we first connect to Redis and store a reference to the connec
 
 Next, we create a Python dictionary to represent a person object.
 
-And finally, we store the object in Redis using the `json().set()` method. The first argument, `person:1` is the name of the key that will reference the JSON. The second argument is a JSON path. We use `Path.root_path()`, as this is a new object. Finally, we pass in the Python dictionary, which will be serialized to JSON.
+And finally, we store the object in Redis using the `json().set()` method. The first argument, `person:1` is the name of the key that will reference the JSON. The second argument is a JSON path. We use `$`, as this is a new object. Finally, we pass in the Python dictionary, which will be serialized to JSON.
 
 To retrieve the JSON object, we run `json().get()`, passing in the key. The result is a Python dictionary representing the JSON object stored in Redis.
 


### PR DESCRIPTION
While redis-py supports rejson v1 and v2 APIs, the default root_path is '.' and not '$'. This specifically exists so as to not break our existing customers, and is in the process of changing (though it is a breaking change). As a result, I'm updating the public example, so that at least our users are using the multi-select v2 API from the onset.