### PR TITLE
Jan 26 schedule update.

### DIFF
--- a/docs/get-involved/redis-live/index-redis-live.mdx
+++ b/docs/get-involved/redis-live/index-redis-live.mdx
@@ -24,7 +24,7 @@ Check out our upcoming events:
 
 |        Date             |    Time      | Streamers                                                                                             | Show                                                                                                 |
 | :---------------------: | :----------: | :---------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
-| Thursday, January 26    | 10:30 AM UTC | [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays: More Redis Streams!][twitch]                                           |
+| Thursday, February 2    | 10:30 AM UTC | [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays: More Redis Streams! (Episode 2)][twitch]                               |
 
   </TabItem>
   <TabItem value="recurring">
@@ -45,8 +45,11 @@ Past events:
 
 |         Date           |    Time      | Streamers                                                                                             | Show                                                                                             |
 | :-------------------:  | :----------: | :---------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------- |
-| Friday, January 20      | 6:00 PM UTC  | [Savannnah Norem][norem], [Justin Castilla][justin]                                                  | [This Week On Discord][78]                                                                       |
-| Wednesday, January 18   | 3:00 PM PST  | [Justin Castilla][justin]                                                                            | [Do Birds dream in JSON? (Integrating Fast API)][77]                                             |
+| Thursday, January 26   | 10:30 AM UTC | [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays: More Redis Streams! (Episode 1)][81]                               |
+| Tuesday, January 24    | 2:00 PM ET   | [Savannah Norem][norem]                                                                               | [savannah_streams_in_snake_case][80]                                                             |
+| Monday, January 23     | 3:00 PM PST  | [Justin Castilla][justin]                                                                             | [Do Birds Dream in JSON? - Episode 7][79]                                                        |
+| Friday, January 20     | 6:00 PM UTC  | [Savannnah Norem][norem], [Justin Castilla][justin]                                                   | [This Week On Discord][78]                                                                       |
+| Wednesday, January 18  | 3:00 PM PST  | [Justin Castilla][justin]                                                                             | [Do Birds Dream in JSON? (Episode 6 - Integrating Fast API)][77]                                 |
 | Tuesday, January 17    | 2:00 PM ET   | [Savannah Norem][norem]                                                                               | [savannah_streams_in_snake_case][76]                                                             |
 | Friday, January 13     | 6:00 PM UTC  | [Suze Shardlow][Suze], [Savannnah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin]| [This Week On Discord][75]                                                                       |
 | Thursday, January 12   | 4:00 PM UTC  | [Suze Shardlow][Suze] and [Simon Prickett][simon]                                                     | [Weekly Redis University Office Hours][officehrs]                                                |
@@ -56,7 +59,7 @@ Past events:
 | Friday, December 16    | 6:00 PM UTC  | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [This Week On Discord][72]                                                                       |
 | Thursday, December 15  | 4:00 PM UTC  | [Suze Shardlow][Suze] and [Simon Prickett][simon]                                                     | [Redis University Office Hours][officehrs]                                                       |
 | Thursday, December 15  | 10:30 AM UTC | [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays: Node-RED Episode 2][71]                                            |
-| Monday, December 12    | 3:00 PM PST  | [Justin Castilla][justin]                                                                             | [Do birds dream in JSON?][70]                                                                    |
+| Monday, December 12    | 3:00 PM PST  | [Justin Castilla][justin]                                                                             | [Do Birds Dream in JSON? - Episode 5][70]                                                        |
 | Friday, December 9     | 12:30 PM PST | [Savannah Norem][norem], [Justin Castilla][justin]                                                    | [RU204: Live Day 5][69]                                                                          |
 | Friday, December 9     | 6:00 PM UTC  | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [This Week On Discord][68]                                                                       |
 | Thursday, December 8   | 12:30 PM PST | [Savannah Norem][norem], [Justin Castilla][justin]                                                    | [RU204: Live Day 4][67]                                                                          |
@@ -64,7 +67,7 @@ Past events:
 | Thursday, December 8   | 10:30 AM UTC | [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays: Node-RED Episode 1][66]                                            |
 | Wednesday, December 7  | 12:30 PM PST | [Savannah Norem][norem], [Justin Castilla][justin]                                                    | [RU204: Live Day 3][65]                                                                          |
 | Tuesday, December 6    | 12:30 PM PST | [Savannah Norem][norem], [Justin Castilla][justin]                                                    | [RU204: Live Day 2][64]                                                                          |
-| Monday, December 5     | 3:00 PM PST  | [Justin Castilla][justin]                                                                             | [Do birds dream in JSON?][63]                                                                    |
+| Monday, December 5     | 3:00 PM PST  | [Justin Castilla][justin]                                                                             | [Do Birds Dream in JSON? - Episode 4][63]                                                        |
 | Monday, December 5     | 12:30 PM PST | [Savannah Norem][norem], [Justin Castilla][justin]                                                    | [RU204: Live Day 1][62]                                                                          |
 | Friday, December 2     | 6:00 PM UTC  | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [This Week On Discord][61]                                                                       |
 | Thursday, December 1   | 4:00 PM UTC  | [Suze Shardlow][Suze], [Simon Prickett][simon] and [Justin Castilla][justin]                          | [Redis University Office Hours][officehrs]                                                       |
@@ -73,17 +76,17 @@ Past events:
 | Thursday, November 24  | 4:00 PM UTC  | [Suze Shardlow][Suze] and [Simon Prickett][simon]                                                     | [Redis University Office Hours][officehrs]                                                       |
 | Thursday, November 24  | 10:30 AM UTC | [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays: Synchronized Counting with Keyspace Notifications - Episode 2][58] |
 | Tuesday, November 22   | 6:00 PM UTC  | [Savannah Norem][norem] .                                                                             | [savannah_streams_in_snake_case][57]                                                             |
-| Monday, November 21    | 3:00 PM PST  | [Justin Castilla][justin]                                                                             | [Do birds dream in JSON? - Episode 3][56]                                                        |
+| Monday, November 21    | 3:00 PM PST  | [Justin Castilla][justin]                                                                             | [Do Birds Dream in JSON? - Episode 3][56]                                                        |
 | Friday, November 18    | 6:00 PM UTC  | [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin]                        | [This Week On Discord][55]                                                                       |
 | Thursday, November 17  | 4:00 PM UTC  | [Justin Castilla][justin]                                                                             | [Redis University Office Hours][officehrs]                                                       |
 | Thursday, November 17  | 10:30 AM UTC | [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays: Synchronized Counting with Keyspace Notifications - Episode 1][54] |
-| Monday, November 14    | 3:00 PM PST  | [Justin Castilla][justin]                                                                             | [Do birds dream in JSON? - Episode 2][53]                                                        |
+| Monday, November 14    | 3:00 PM PST  | [Justin Castilla][justin]                                                                             | [Do Birds Dream in JSON? - Episode 2][53]                                                        |
 | Thursday, November 10  | 6:00 PM UTC  | [Savannah Norem][norem] and [Justin Castilla][justin]                                                 | [This Week On Discord][52]                                                                       |
 | Thursday, November 10  | 4:00 PM UTC  | [Savannah Norem][norem] and [Justin Castilla][justin]                                                 | [Redis University Office Hours][officehrs]                                                       |
 | Friday, November 4     | 5:00 PM UTC  | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [This Week On Discord][51]                                                                       |
 | Thursday, November 3   | 3:00 PM UTC  | [Suze Shardlow][Suze], [Savannah Norem][norem], [Simon Prickett][simon] and [Justin Castilla][justin] | [Redis University Office Hours][officehrs]                                                       |
 | Thursday, November 3   | 9:30 AM UTC  | [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays - Cheerlights with MQTT and Redis Streams][50]                      |
-| Monday, October 31     | 10:00 PM UTC | [Justin Castilla][justin]                                                                             | [Do birds dream in JSON? - Episode 1][49]                                                        |
+| Monday, October 31     | 10:00 PM UTC | [Justin Castilla][justin]                                                                             | [Do Birds Dream in JSON? - Episode 1][49]                                                        |
 | Friday, October 28     | 5:00 PM UTC  | [Suze Shardlow][Suze], [Simon Prickett][simon] and [Justin Castilla][justin]                          | [This Week On Discord][48]                                                                       |
 | Thursday, October 27   | 3:00 PM UTC  | [Suze Shardlow][Suze] and [Simon Prickett][simon]                                                     | [Weekly Redis University Office Hours][officehrs]                                                |
 | Thursday, October 27   | 9:30 AM UTC  | [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays - Raspberry Pi Pico W - Episode 5][47]                              |
@@ -174,6 +177,9 @@ Past events:
 [officehrs]: https://discord.com/channels/697882427875393627/981667564570706000
 
 <!-- Links to specific videos -->
+[81]: https://www.youtube.com/watch?v=NCvHfB7BhfQ
+[80]: https://www.youtube.com/watch?v=T0UEY97ZhZY
+[79]: https://www.youtube.com/watch?v=TpMNJNEI7co
 [78]: https://www.youtube.com/watch?v=EyVe5OmoyI4
 [77]: https://www.youtube.com/watch?v=LpdShJOZuwA
 [76]: https://www.youtube.com/watch?v=0pxI00YpusU


### PR DESCRIPTION
Updates the schedule with:

* Added Simon's February 2nd livestream
* Added Justin's Jan 23 livestream to Past tad, abbs YT link
* Added Savannah's Jan 24 livestream to Past tad, abbs YT link
* Moved Simon's Jan 26th livestream to Past tab, adds YT link