### PR TITLE
Moved Feb 2 livestream to past, added link.

### DIFF
--- a/docs/get-involved/redis-live/index-redis-live.mdx
+++ b/docs/get-involved/redis-live/index-redis-live.mdx
@@ -24,7 +24,6 @@ Check out our upcoming events:
 
 |        Date             |    Time      | Streamers                                                                                             | Show                                                                                                 |
 | :---------------------: | :----------: | :---------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
-| Thursday, February 2    | 10:30 AM UTC | [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays: More Redis Streams! (Episode 2)][twitch]                               |
 
   </TabItem>
   <TabItem value="recurring">
@@ -44,6 +43,7 @@ Past events:
 
 |         Date           |    Time      | Streamers                                                                                             | Show                                                                                             |
 | :-------------------:  | :----------: | :---------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------- |
+| Thursday, February 2   | 12:00 PM UTC | [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays: More Redis Streams! (Episode 2)][82]                               |
 | Thursday, January 26   | 10:30 AM UTC | [Simon Prickett][simon]                                                                               | [Simon's Things on Thursdays: More Redis Streams! (Episode 1)][81]                               |
 | Tuesday, January 24    | 2:00 PM ET   | [Savannah Norem][norem]                                                                               | [savannah_streams_in_snake_case][80]                                                             |
 | Monday, January 23     | 3:00 PM PST  | [Justin Castilla][justin]                                                                             | [Do Birds Dream in JSON? - Episode 7][79]                                                        |
@@ -176,6 +176,7 @@ Past events:
 [officehrs]: https://discord.com/channels/697882427875393627/981667564570706000
 
 <!-- Links to specific videos -->
+[82]: https://www.youtube.com/watch?v=qzFUZ7aBCEo
 [81]: https://www.youtube.com/watch?v=NCvHfB7BhfQ
 [80]: https://www.youtube.com/watch?v=T0UEY97ZhZY
 [79]: https://www.youtube.com/watch?v=TpMNJNEI7co


### PR DESCRIPTION
Moved Simon's Feb 2nd IoT livestream to the past tab, added a link to it.