### PR TITLE
Schedule update March 2.  Moved Plane Spotting Episode 4 adds link.

### DIFF
--- a/docs/get-involved/redis-live/index-redis-live.mdx
+++ b/docs/get-involved/redis-live/index-redis-live.mdx
@@ -24,7 +24,6 @@ Check out our upcoming events:
 
 |        Date             |    Time      | Streamers                                                                                             | Show                                                                                                 |
 | :---------------------: | :----------: | :---------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
-| Thursday, March 2       | 2:00 PM UTC  | [Simon Prickett][simon]                                                                               | [Simon's Redis IoT Show: Plane Spotting with Redis and Node.js Episode 4][twitch]                    |
 
   </TabItem>
   <TabItem value="recurring">
@@ -43,6 +42,7 @@ Past events:
 
 |         Date           |    Time      | Streamers                                                                                             | Show                                                                                             |
 | :-------------------:  | :----------: | :---------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------- |
+| Thursday, March 2      | 2:00 PM UTC  | [Simon Prickett][simon]                                                                               | [Simon's Redis IoT Show: Plane Spotting with Redis and Node.js Episode 4][89]                    |
 | Friday, February 24    | 12:00 PM UTC | [Simon Prickett][simon]                                                                               | [Simon's Redis IoT Show: Plane Spotting with Redis and Node.js Episode 3][88]                    |
 | Tuesday, February 21   | 7:00 PM UTC  | [Savannah Norem][norem]                                                                               | [savannah_streams_in_snake_case A Game! Ep 3][87]                                                |
 | Monday, February 20    | 2:00 PM UTC  | [Simon Prickett][simon]                                                                               | [Simon's Redis IoT Show: Plane Spotting with Redis and Node.js Episode 2][86]                    |
@@ -182,6 +182,7 @@ Past events:
 [officehrs]: https://discord.com/channels/697882427875393627/981667564570706000
 
 <!-- Links to specific videos -->
+[89]: https://www.youtube.com/watch?v=fYnrNqSgqR4
 [88]: https://www.youtube.com/watch?v=IEx2WgWdhIA
 [87]: https://www.youtube.com/watch?v=zWJ2mQOXlq8
 [86]: https://www.youtube.com/watch?v=Qu-_wvSJrdE


### PR DESCRIPTION
Updated the schedule after Simon's March 2nd livestream.  @justincastilla @savynorem  note the upcoming schedule is now empty, please add anything you have coming up in subsequent PRs.