### PR TITLE
Fix typo in `index-riot.mdx`

### DIFF
--- a/docs/explore/riot/index-riot.mdx
+++ b/docs/explore/riot/index-riot.mdx
@@ -48,7 +48,7 @@ cd riot/riot-redis
 ### Step 3. Install via Homebrew (macOS)
 
 ```
-brew install jruaux/tap/riot-redis`
+brew install jruaux/tap/riot-redis
 ```
 
 ### Usage


### PR DESCRIPTION
Hello, this is just a small typo fix on this page: [RIOT | The Home of Redis Developers](https://developer.redis.com/explore/riot#step-3-install-via-homebrew-macos)

<img width="813" alt="Screenshot 2023-04-11 at 0 26 18" src="https://user-images.githubusercontent.com/1425259/230932596-007d5707-ae56-46ad-bbdd-5af5653a15b8.png">
